### PR TITLE
Fixed issue introduced by PR #2 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,19 @@
 CPPRay
 ======
 
-A minimalistic pathtracer written in C++, inspiration taken from projects like [smallpt](http://kevinbeason.com/smallpt/).
+A minimalistic path tracer written in C++, inspiration taken from projects like [smallpt](http://kevinbeason.com/smallpt/).
 
 Example Images:
 ---------------
 
-![512x512 render @ 1000SPPX, .obj meshes](images/cppray1.png)
-_512x512 render @ 1000SPPX, .obj meshes_
+![512x512 render @ 1000SPPX](images/cppray1.png "512x512 render @ 1000SPPX - .obj meshes.")
 
-![512x512 render @ 200SPPX, Cook-torrance microfacet brdf model for glossy specular materials](images/glossy1.png)
-_512x512 render @ 200SPPX, Cook-torrance microfacet brdf model for glossy specular materials_
+_512x512 render @ 1000SPPX - .obj meshes._
 
-![512x512 render @ 1000SPPX, Glossy floor, triangles implemented](images/glossy2.png)
-_512x512 render @ 1000SPPX, Glossy floor, triangles implemented_
+![512x512 render @ 200SPPX](images/glossy1.png "512x512 render @ 200SPPX - Cook-torrance microfacet brdf model for glossy specular materials.")
+
+_512x512 render @ 200SPPX - Cook-torrance microfacet brdf model for glossy specular materials._
+
+![512x512 render @ 1000SPPX](images/glossy2.png "512x512 render @ 1000SPPX - Glossy floor; triangles implemented.")
+
+_512x512 render @ 1000SPPX - Glossy floor; triangles implemented._


### PR DESCRIPTION
I accidentally broke the subtitles for the images in the README (in #2) and caused them to appear on the same line as the image. I fixed this and gave all images a title="" element so that text appears when hovering over the images.

Also ran the file trough aspell and split the word "pathtracer" into two words.

Things should look nicer now.